### PR TITLE
Fix yvals_core.h

### DIFF
--- a/include/Version.h
+++ b/include/Version.h
@@ -1,7 +1,10 @@
+#ifndef VERSION_H
+#define VERSION_H
+
 #define FILE_VERSION_MAJOR 2
 #define FILE_VERSION_MINOR 0
 #define FILE_VERSION_PATCH 7
-#define FILE_VERSION_BUILD 2
+#define FILE_VERSION_BUILD 3
 #define FILE_VERSION_STABLE 0 // 1 for stable, 0 for prerelease
 
 #define STRINGIFY(x) #x
@@ -9,32 +12,40 @@
 
 #define RVO_VERSION TOSTRING(FILE_VERSION_MAJOR) "." TOSTRING(FILE_VERSION_MINOR) "." TOSTRING(FILE_VERSION_PATCH) "." TOSTRING(FILE_VERSION_BUILD)
 
+#ifdef __cplusplus
 #include <string>
 #include <sstream>
 #include <iomanip>
 #include <ctime>
-#include <iostream>
 
-std::string getVersionFromDateTime() {
-    std::tm t = {};
-    std::istringstream date_ss(__DATE__);
-    date_ss >> std::get_time(&t, "%b %d %Y");
-
-    std::istringstream time_ss(__TIME__);
-    time_ss >> std::get_time(&t, "%H:%M:%S");
-
-    std::ostringstream version_ss;
-    version_ss << std::setfill('0') << std::setw(2) << (t.tm_year % 100)
-               << std::setw(2) << (t.tm_mon + 1)
-               << std::setw(2) << t.tm_mday
-               << std::setw(2) << t.tm_hour
-               << std::setw(2) << t.tm_min;
-
-    return version_ss.str();
+// Implementation of getVersionFromDateTime function
+inline std::string getVersionFromDateTime() {
+    // Get current time
+    std::time_t t = std::time(nullptr);
+    std::tm* tm_ptr = std::localtime(&t);
+    
+    // Format as YYYYMMDD
+    std::ostringstream oss;
+    oss << std::setfill('0') 
+        << std::setw(4) << (tm_ptr->tm_year + 1900)
+        << std::setw(2) << (tm_ptr->tm_mon + 1)
+        << std::setw(2) << tm_ptr->tm_mday;
+    
+    return oss.str();
 }
 
-const std::string RVO_COMPILATION = getVersionFromDateTime();
-
-std::string releaseType() {
-    return (FILE_VERSION_STABLE == 1) ? "Stable" : "PreRelease";
+// Implementation of releaseType function
+inline std::string releaseType() {
+    if (FILE_VERSION_STABLE == 1) {
+        return "Stable";
+    } else {
+        return "Pre-release";
+    }
 }
+
+// Define RVO_COMPILATION as a macro to avoid multiple definition issues
+#define RVO_COMPILATION getVersionFromDateTime()
+
+#endif // __cplusplus
+
+#endif // VERSION_H


### PR DESCRIPTION
Microsoft Visual Studio\2022\Community\VC\Tools\Llvm\x64\lib\clang\19\include\yvals_core.h(11): fatal error RC1021: invalid preprocessor command 'include_next'