### PR TITLE
Upgrade solution/project to VS 18 and add .slnx

### DIFF
--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -20,7 +20,7 @@ on:
         type: boolean
 
 env:
-  SOLUTION_FILE_PATH: RealViewOn.sln
+  SOLUTION_FILE_PATH: RealViewOn.slnx
   BUILD_CONFIGURATION: Release
 
 permissions:

--- a/RealViewOn.sln
+++ b/RealViewOn.sln
@@ -1,8 +1,8 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.12.35506.116
-MinimumVisualStudioVersion = 10.0.40219.1
+# Visual Studio Version 18
+VisualStudioVersion = 18.0.0.0
+MinimumVisualStudioVersion = 17.0.0.0
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "RealViewOn", "RealViewOn.vcxproj", "{36FD3B22-B095-47E5-9E45-A4050E4CC122}"
 EndProject
 

--- a/RealViewOn.slnx
+++ b/RealViewOn.slnx
@@ -1,0 +1,7 @@
+<Solution>
+  <Configurations>
+    <BuildType Name="Release" />
+    <Platform Name="x64" />
+  </Configurations>
+  <Project Path="RealViewOn.vcxproj" Id="36fd3b22-b095-47e5-9e45-a4050e4cc122" />
+</Solution>

--- a/RealViewOn.vcxproj
+++ b/RealViewOn.vcxproj
@@ -7,7 +7,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <VCProjectVersion>17.0</VCProjectVersion>
+    <VCProjectVersion>18.0</VCProjectVersion>
     <Keyword>Win32Proj</Keyword>
     <ProjectGuid>{36fd3b22-b095-47e5-9e45-a4050e4cc122}</ProjectGuid>
     <RootNamespace>RealViewOn</RootNamespace>


### PR DESCRIPTION
Target VS 18 across the repository and switch CI to the new solution file. Updated GitHub Actions env to point to RealViewOn.slnx, added RealViewOn.slnx containing Release/x64 configuration and project mapping, bumped VisualStudioVersion and MinimumVisualStudioVersion in RealViewOn.sln, and updated VCProjectVersion in RealViewOn.vcxproj from 17.0 to 18.0 to match the newer toolset.