### PR TITLE
Skip Dependabot commits in changelog

### DIFF
--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -230,6 +230,19 @@ jobs:
                       $shortHash = $parts[1].Trim()
                       $subject = $parts[2].Trim()
 
+                      # Omitir commits automáticos de Dependabot para no incluirlos en What's Changed
+                      $authorName = "$(git show -s --format:\"%an\" $fullHash)".Trim()
+                      $authorEmail = "$(git show -s --format:\"%ae\" $fullHash)".Trim()
+                      $isDependabotCommit = $subject -match '(?i)^Merge pull request #\d+ from dependabot/' -or
+                                             $subject -match '(?i)^Bump .+ from .+ to .+' -or
+                                             $authorName -match '(?i)^dependabot(\[bot\])?$' -or
+                                             $authorEmail -match '(?i)dependabot'
+
+                      if ($isDependabotCommit) {
+                        Write-Host "  🤖 Commit $shortHash omitido (Dependabot): $subject"
+                        continue
+                      }
+
                       Write-Host "🔍 Procesando commit $shortHash : $subject"
 
                       # Verificar si el commit modificó solo archivos que no interesan para el changelog


### PR DESCRIPTION
Add PowerShell checks to .github/workflows/msbuild.yml to omit Dependabot automated commits from the What's Changed output. The new logic inspects commit subject and author name/email (using git show) for Dependabot-related patterns (merge from dependabot, Bump ... from ... to ..., or author/email containing dependabot) and skips those commits while logging a short message. This keeps the changelog focused on human-authored changes.