### PR TITLE
CodeQL: configure C/C++ manual build on Windows

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,7 +27,7 @@ jobs:
     #   - https://gh.io/supported-runners-and-hardware-resources
     #   - https://gh.io/using-larger-runners (GitHub.com only)
     # Consider using larger runners or machines with greater resources for possible analysis time improvements.
-    runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
+    runs-on: ${{ matrix.runs-on }}
     permissions:
       # required for all workflows
       security-events: write
@@ -45,8 +45,10 @@ jobs:
         include:
         - language: actions
           build-mode: none
+          runs-on: ubuntu-latest
         - language: c-cpp
-          build-mode: autobuild
+          build-mode: manual
+          runs-on: windows-latest
         # CodeQL supports the following values keywords for 'language': 'actions', 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'rust', 'swift'
         # Use `c-cpp` to analyze code written in C, C++ or both
         # Use 'java-kotlin' to analyze code written in Java, Kotlin or both
@@ -78,22 +80,11 @@ jobs:
         # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
         # queries: security-extended,security-and-quality
 
-    # If the analyze step fails for one of the languages you are analyzing with
-    # "We were unable to automatically build your code", modify the matrix above
-    # to set the build mode to "manual" for that language. Then modify this step
-    # to build your code.
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
-    - name: Run manual build steps
-      if: matrix.build-mode == 'manual'
-      shell: bash
+    - name: Build C/C++ project (manual)
+      if: matrix.language == 'c-cpp' && matrix.build-mode == 'manual'
+      shell: pwsh
       run: |
-        echo 'If you are using a "manual" build mode for one or more of the' \
-          'languages you are analyzing, replace this with the commands to build' \
-          'your code, for example:'
-        echo '  make bootstrap'
-        echo '  make release'
-        exit 1
+        msbuild RealViewOn.vcxproj /m /p:Configuration=Release /p:Platform=x64
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v4

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -61,6 +61,10 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
 
+    - name: Setup MSBuild
+      if: matrix.language == 'c-cpp'
+      uses: microsoft/setup-msbuild@v2
+
     # Add any setup steps before running the `github/codeql-action/init` action.
     # This includes steps like installing compilers or runtimes (`actions/setup-node`
     # or others). This is typically only required for manual builds.


### PR DESCRIPTION
Use matrix.runs-on for runner selection and add per-language runs-on entries. Change c-cpp build-mode to manual and run its build step only when matrix.language == 'c-cpp' && matrix.build-mode == 'manual'. Switch the build step to PowerShell and invoke msbuild (RealViewOn.vcxproj /m /p:Configuration=Release /p:Platform=x64). Also add ubuntu-latest for the actions matrix entry and remove the placeholder bash instructions.