### PR TITLE
Add automated vendored tools update workflow

### DIFF
--- a/.github/workflows/update-tools.yml
+++ b/.github/workflows/update-tools.yml
@@ -1,0 +1,175 @@
+# Bot de actualizacion de los binarios vendorizados en tools/.
+#
+# Compara tools/upx.exe y tools/7zr.exe contra el ultimo release ESTABLE de
+# upx/upx y ip7z/7zip. Si hay novedad: descarga el asset, verifica arquitectura,
+# corre una prueba funcional real con los mismos flags que usa el pipeline de
+# release y abre un PR con el binario y tools/tools.lock.json actualizados.
+#
+# Toda la logica esta en tools/Update-VendoredTools.ps1, que se puede correr a
+# mano:  pwsh tools/Update-VendoredTools.ps1 -CheckOnly
+#
+# REQUISITO DE CONFIGURACION: Settings > Actions > General > Workflow permissions
+# > "Allow GitHub Actions to create and approve pull requests" tiene que estar
+# habilitado, o `gh pr create` falla con 403.
+
+name: Update vendored tools
+
+on:
+  schedule:
+    # Lunes 06:00 UTC.
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+    inputs:
+      tool:
+        description: 'Herramienta a revisar'
+        type: choice
+        options: [all, upx, 7zr]
+        default: all
+      check_only:
+        description: 'Solo informar la comparacion, sin descargar ni abrir PR'
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+# Dos corridas simultaneas empujarian la misma rama. No se cancela la que ya
+# estaba: puede estar a mitad de un push.
+concurrency:
+  group: update-tools
+  cancel-in-progress: false
+
+jobs:
+  discover:
+    name: Leer tools.lock.json
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set.outputs.matrix }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Armar la matriz de herramientas
+        id: set
+        shell: pwsh
+        run: |
+          $lock = Get-Content tools/tools.lock.json -Raw | ConvertFrom-Json
+          $pedido = '${{ inputs.tool }}'
+          if ([string]::IsNullOrWhiteSpace($pedido)) { $pedido = 'all' }  # corridas por schedule
+
+          # @() externo: una rama de if que devuelve un array vacio se colapsa a
+          # $null al asignarla, y el .Count de abajo dejaria de detectarlo.
+          $ids = @(if ($pedido -eq 'all') { $lock.tools | ForEach-Object { $_.id } } else { $pedido })
+          if ($ids.Count -eq 0) { throw "tools.lock.json no define ninguna herramienta." }
+
+          $matrix = '{"id":' + ($ids | ConvertTo-Json -Compress -AsArray) + '}'
+          Write-Host "matriz: $matrix"
+          "matrix=$matrix" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+
+  update:
+    name: ${{ matrix.id }}
+    needs: discover
+    # windows-latest es obligatorio: la prueba funcional ejecuta los .exe.
+    runs-on: windows-latest
+    timeout-minutes: 30
+    permissions:
+      contents: write
+      pull-requests: write
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.discover.outputs.matrix) }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Comparar con el origen y actualizar el binario
+        id: update
+        shell: pwsh
+        env:
+          # Solo para el limite de la API de GitHub (60 req/h por IP sin token).
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          $p = @{ Id = '${{ matrix.id }}'; PrBodyPath = "$env:RUNNER_TEMP/pr-body.md" }
+          if ('${{ inputs.check_only }}' -eq 'true') { $p['CheckOnly'] = $true }
+          ./tools/Update-VendoredTools.ps1 @p
+
+      - name: Buscar un PR previo para esta version
+        id: existing
+        if: steps.update.outputs.updated == 'true'
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          $branch = 'bot/update-${{ matrix.id }}-${{ steps.update.outputs.latest_version }}'
+          "branch=$branch" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+
+          # --state all a proposito: si ya se cerro un PR para esta misma version,
+          # el mantenedor ya decidio y el bot no tiene que volver a insistir.
+          $prs = @(gh pr list --head $branch --state all --json url,state --limit 5 | ConvertFrom-Json)
+          if ($prs.Count -gt 0) {
+            Write-Host "::notice::Ya existe un PR para $branch ($($prs[0].state)): $($prs[0].url)"
+            "skip=true" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          } else {
+            "skip=false" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          }
+
+      - name: Abrir el pull request
+        id: pr
+        if: steps.update.outputs.updated == 'true' && steps.existing.outputs.skip == 'false'
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          $branch = '${{ steps.existing.outputs.branch }}'
+          $id     = '${{ matrix.id }}'
+          $nombre = '${{ steps.update.outputs.name }}'
+          $vieja  = '${{ steps.update.outputs.current_version }}'
+          $nueva  = '${{ steps.update.outputs.latest_version }}'
+          $ruta   = '${{ steps.update.outputs.path }}'
+
+          git config user.name  'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git checkout -b $branch
+
+          # Rutas explicitas: tools/ tiene .gitignore para *.exe y no se quiere
+          # arrastrar nada mas que el binario y el lock.
+          git add -- $ruta tools/tools.lock.json
+          $staged = @(git diff --cached --name-only)
+          if ($staged.Count -eq 0) {
+            throw "No quedo nada en el index. Se esperaba $ruta y tools/tools.lock.json."
+          }
+          Write-Host "staged: $($staged -join ', ')"
+
+          $titulo = "chore(tools): $nombre $vieja -> $nueva"
+          git commit -m $titulo -m "Origen: ${{ steps.update.outputs.release_url }}" -m "SHA256: ${{ steps.update.outputs.sha256_new }}"
+          git push --set-upstream origin $branch
+
+          # El cuerpo lo genero el script en el paso anterior (New-CuerpoPr).
+          $cuerpo = "$env:RUNNER_TEMP/pr-body.md"
+          if (-not (Test-Path $cuerpo)) { throw "Falta el cuerpo del PR en $cuerpo." }
+          $url = gh pr create --base main --head $branch --title $titulo --body-file $cuerpo
+          Write-Host "::notice::PR creado: $url"
+          "url=$url" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+
+      - name: Resumen
+        if: always()
+        shell: pwsh
+        run: |
+          $tieneNovedad = '${{ steps.update.outputs.has_update }}' -eq 'true'
+          $actualizado  = '${{ steps.update.outputs.updated }}' -eq 'true'
+          $salteado     = '${{ steps.existing.outputs.skip }}' -eq 'true'
+          $vieja = '${{ steps.update.outputs.current_version }}'
+          $nueva = '${{ steps.update.outputs.latest_version }}'
+
+          # if/elseif en una sola linea cada uno: PowerShell no acepta un salto de
+          # linea entre "}" y "elseif".
+          $estado = '⚠️ Sin completar, revisar el log'
+          if (-not $tieneNovedad) { $estado = "✅ Al dia (``$vieja``)" }
+          elseif ('${{ inputs.check_only }}' -eq 'true') { $estado = "🔍 Hay ``$nueva`` disponible (check_only, sin PR)" }
+          elseif ($salteado) { $estado = "⏭️ Ya existe un PR para ``$nueva``" }
+          elseif ($actualizado) { $estado = "🚀 PR abierto: ``$vieja`` → ``$nueva`` — ${{ steps.pr.outputs.url }}" }
+
+          "## ${{ matrix.id }}"  | Out-File $env:GITHUB_STEP_SUMMARY -Append
+          ""                     | Out-File $env:GITHUB_STEP_SUMMARY -Append
+          $estado                | Out-File $env:GITHUB_STEP_SUMMARY -Append

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,114 @@
+# tools/
+
+Utilidades del pipeline de release.
+
+| Archivo | Que es |
+| --- | --- |
+| [`upx.exe`](upx.exe) | [UPX](https://github.com/upx/upx), comprime `RealViewOn.exe`. Build **x64**. |
+| [`7zr.exe`](7zr.exe) | [7-Zip](https://github.com/ip7z/7zip) consola standalone, arma `RealViewOn.7z`. Build **x86**. |
+| [`tools.lock.json`](tools.lock.json) | Versiones y SHA256 fijados de los dos binarios de arriba. |
+| [`Update-VendoredTools.ps1`](Update-VendoredTools.ps1) | Compara los binarios contra su origen y los actualiza. |
+| [`ReleaseUPXZIP.bat`](ReleaseUPXZIP.bat) | PostBuildEvent: copia, comprime con UPX y empaqueta con 7-Zip. |
+| [`GetWorka.ps1`](GetWorka.ps1) | Script auxiliar para recolectar datos de workarounds. |
+
+## Actualizacion automatica
+
+[`.github/workflows/update-tools.yml`](../.github/workflows/update-tools.yml) corre
+los lunes a las 06:00 UTC. Para cada herramienta de `tools.lock.json`:
+
+1. Lista los releases del repo de origen y descarta drafts, prereleases y
+   cualquier tag o nombre que parezca `alpha` / `beta` / `rc` / `preview`.
+   El flag `prerelease` de GitHub no alcanza por si solo: ni `upx/upx` ni
+   `ip7z/7zip` lo usan, asi que un "26.03 beta" llegaria como release normal.
+2. Elige el estable mas nuevo **comparando numeros de version**, no fechas: un
+   parche de una linea vieja publicado despues no debe ganarle a una minor nueva.
+3. Si hay novedad, descarga el asset, extrae el ejecutable y **verifica antes de
+   reemplazar nada**:
+   - la arquitectura leida del encabezado PE coincide con la fijada en el lock;
+   - una prueba funcional real con los mismos flags que usa el release.
+4. Reemplaza el binario, actualiza `version` y `sha256` en el lock, y abre un PR.
+
+Si cualquier verificacion falla, el binario del repo **queda intacto** y el job
+falla en rojo.
+
+### Las pruebas funcionales
+
+Un binario que descarga bien pero no comprime no sirve, asi que no alcanza con
+mirar la version:
+
+- **UPX** — comprime una copia de `tools/7zr.exe` (un PE real y chico que ya esta
+  en el repo) con `--ultra-brute`, comprueba que el tamano bajo, valida el
+  resultado con `upx -t` y **ejecuta el binario comprimido** para confirmar que
+  todavia corre. Es exactamente lo que el pipeline le hace a `RealViewOn.exe`.
+- **7zr** — crea un `.7z` con `a -t7z -mx=9 -md=1m -ms=on` (los flags del paso
+  "Prepare release assets"), lo valida con `7zr t`, lo extrae y compara el SHA256
+  del contenido contra el original.
+
+### Correrlo a mano
+
+```powershell
+# Solo informar si hay actualizaciones. No toca el working tree.
+pwsh tools/Update-VendoredTools.ps1 -CheckOnly
+
+# Actualizar una herramienta (descarga, verifica y reemplaza el binario + el lock).
+pwsh tools/Update-VendoredTools.ps1 -Id upx
+
+# Todas.
+pwsh tools/Update-VendoredTools.ps1
+```
+
+Sin token la API de GitHub permite 60 requests por hora y por IP. Si se agota:
+
+```powershell
+$env:GITHUB_TOKEN = 'ghp_...'   # basta un token sin scopes, solo sube el limite
+pwsh tools/Update-VendoredTools.ps1 -CheckOnly
+```
+
+### Agregar otra herramienta
+
+Sumar una entrada a `tools.lock.json`; la matriz del workflow se arma leyendo ese
+archivo, no hace falta tocar el YAML. Campos:
+
+| Campo | Para que |
+| --- | --- |
+| `id` | Identificador corto. Es el valor de `-Id` y el nombre del job. |
+| `path` | Ruta del binario, relativa a la raiz del repo. |
+| `repo` | `owner/name` del repositorio de origen en GitHub. |
+| `version` | Version fijada actualmente. La actualiza el bot. |
+| `arch` | `x64`, `x86` o `ARM64`. Se valida contra el encabezado PE. |
+| `asset` | Nombre del asset del release. `{version}` se reemplaza. |
+| `archiveMember` | Ruta dentro del zip, o `null` si el asset ya es el `.exe`. |
+| `sha256` | Hash del binario fijado. Lo actualiza el bot. |
+| `usedBy` | Texto libre; aparece en el cuerpo del PR. |
+
+Para que el bot tenga prueba funcional, agregar un `case` en
+`Invoke-PruebaFuncional`. Sin eso la herramienta se actualiza igual, pero el PR
+dice que no hubo prueba.
+
+> El lock se reserializa completo al actualizarse. Si se edita a mano, mantener el
+> formato tal como esta (2 espacios de indentacion, mismo orden de claves) para
+> que el diff del PR muestre solo `version` y `sha256`.
+
+## Coherencia entre el lock y los binarios
+
+Antes de comparar contra el origen, el script verifica que el SHA256 del binario
+en disco coincida con el del lock. Si alguien reemplazo un `.exe` sin actualizar
+el lock, falla y lo dice, en lugar de razonar sobre datos que no son ciertos.
+
+## Que NO hace el bot
+
+- **No verifica procedencia criptografica.** Ni `upx/upx` ni `ip7z/7zip` publican
+  un archivo de checksums en sus releases de GitHub. El bot comprueba que el
+  binario venga del repositorio oficial, que tenga la arquitectura esperada y que
+  funcione, y deja el SHA256 en el cuerpo del PR. Comparar ese hash contra el que
+  publica el proveedor ([UPX](https://github.com/upx/upx/releases),
+  [7-Zip](https://www.7-zip.org/download.html)) queda a cargo de quien revisa.
+- **No mergea.** Solo abre el PR.
+- **No insiste.** Si ya existe un PR para esa version, abierto o cerrado, no crea
+  otro: si se cerro, fue una decision del mantenedor.
+- **No dispara los otros workflows.** Los PRs creados con `GITHUB_TOKEN` no
+  disparan workflows, por diseno de GitHub. Ademas `tools/**` no esta en los
+  `paths` de `tests.yml` ni de `msbuild.yml`, asi que estos PRs no traen CI. Para
+  que un cambio de UPX se pruebe compilando y comprimiendo de verdad, agregar
+  `tools/**` a los `paths` del `pull_request` de `msbuild.yml` y crear el PR con
+  un PAT en lugar de `GITHUB_TOKEN`.

--- a/tools/Update-VendoredTools.ps1
+++ b/tools/Update-VendoredTools.ps1
@@ -1,0 +1,504 @@
+#Requires -Version 7.0
+<#
+.SYNOPSIS
+    Compara los binarios vendorizados en tools/ contra el ultimo release estable de
+    su repositorio de origen y, opcionalmente, los actualiza.
+
+.DESCRIPTION
+    Las versiones fijadas viven en tools/tools.lock.json. Para cada herramienta el
+    script:
+      1. Lista los releases del repo de origen y descarta drafts, prereleases y
+         cualquier tag/nombre que parezca alpha/beta/rc.
+      2. Elige el estable mas nuevo comparando numeros de version (no fechas: un
+         parche de una linea vieja publicado despues no debe ganar).
+      3. Si hay novedad y no se paso -CheckOnly, descarga el asset, extrae el
+         ejecutable, verifica arquitectura, corre una prueba funcional real y
+         recien entonces reemplaza el binario y actualiza el lock.
+
+    NO hace commit ni abre PRs: de eso se encarga
+    .github/workflows/update-tools.yml. Asi el script se puede correr a mano.
+
+.PARAMETER Id
+    Id de la herramienta en el lock ('upx', '7zr') o 'all' para todas.
+
+.PARAMETER CheckOnly
+    Solo compara versiones e informa. No descarga ni modifica nada.
+
+.PARAMETER SkipFunctionalTest
+    Omite la prueba funcional. Solo para depurar; el workflow nunca la usa.
+
+.PARAMETER GitHubToken
+    Token opcional para la API de GitHub. Sin token el limite es 60 req/hora por
+    IP, que en los runners compartidos se agota.
+
+.PARAMETER PrBodyPath
+    Si se indica y hubo actualizacion, escribe ahi el cuerpo markdown del PR. El
+    workflow lo pasa a `gh pr create --body-file`. Se genera aca y no en el YAML
+    porque un here-string de PowerShell no puede vivir dentro de un bloque
+    escalar de YAML (el `"@` de cierre tiene que ir en la columna 0).
+
+.EXAMPLE
+    pwsh tools/Update-VendoredTools.ps1 -CheckOnly
+    Informa si hay actualizaciones sin tocar el working tree.
+
+.EXAMPLE
+    pwsh tools/Update-VendoredTools.ps1 -Id upx
+    Actualiza tools/upx.exe y tools/tools.lock.json si hay un estable mas nuevo.
+#>
+[CmdletBinding()]
+param(
+    [string] $Id = 'all',
+    [string] $RepoRoot,
+    [switch] $CheckOnly,
+    [switch] $SkipFunctionalTest,
+    [string] $GitHubToken = $env:GITHUB_TOKEN,
+    [string] $PrBodyPath
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+$ProgressPreference = 'SilentlyContinue'
+
+# Tags/nombres que no son estables. El flag `prerelease` de GitHub no alcanza:
+# ninguno de los dos upstreams lo usa, asi que un "26.03 beta" llegaria como
+# release normal.
+$PatronInestable = '(?i)(alpha|beta|preview|snapshot|nightly|(^|[^a-z])rc([^a-z]|\d|$))'
+
+function Resolve-RepoRoot {
+    param([string] $Provisto)
+    if ($Provisto) { return (Resolve-Path $Provisto).Path }
+    return (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+}
+
+function Get-LockPath { param([string] $Raiz) Join-Path $Raiz 'tools/tools.lock.json' }
+
+function Read-Lock {
+    param([string] $Raiz)
+    $ruta = Get-LockPath $Raiz
+    if (-not (Test-Path $ruta)) { throw "No se encontro el lock: $ruta" }
+    return Get-Content $ruta -Raw -Encoding utf8 | ConvertFrom-Json
+}
+
+function Write-Lock {
+    param([string] $Raiz, $Lock)
+    # Se reserializa el archivo completo. Para que el diff del PR muestre solo los
+    # campos que cambiaron, el lock versionado tiene que estar escrito exactamente
+    # con este formato (ver la prueba de idempotencia en tools/README.md).
+    $json = ($Lock | ConvertTo-Json -Depth 10)
+    $json = $json -replace "`r`n", "`n"
+    Set-Content -Path (Get-LockPath $Raiz) -Value ($json + "`n") -Encoding utf8NoBOM -NoNewline
+}
+
+function Get-VersionSortKey {
+    param([string] $Version)
+    $partes = @($Version -split '[^0-9]+' | Where-Object { $_ -ne '' } | ForEach-Object { [int]$_ })
+    if ($partes.Count -eq 0) { return '0000000000' }
+    return (($partes | ForEach-Object { $_.ToString('0000000000') }) -join '.')
+}
+
+# Devuelve -1 si A < B, 0 si son iguales, 1 si A > B. Compara componente por
+# componente, asi sirve igual para "5.1.1" (UPX) que para "26.00" (7-Zip).
+function Compare-ToolVersion {
+    param([string] $A, [string] $B)
+    $pa = @($A -split '[^0-9]+' | Where-Object { $_ -ne '' } | ForEach-Object { [int]$_ })
+    $pb = @($B -split '[^0-9]+' | Where-Object { $_ -ne '' } | ForEach-Object { [int]$_ })
+    $n = [Math]::Max($pa.Count, $pb.Count)
+    for ($i = 0; $i -lt $n; $i++) {
+        $x = if ($i -lt $pa.Count) { $pa[$i] } else { 0 }
+        $y = if ($i -lt $pb.Count) { $pb[$i] } else { 0 }
+        if ($x -lt $y) { return -1 }
+        if ($x -gt $y) { return 1 }
+    }
+    return 0
+}
+
+function Get-ApiHeaders {
+    $h = @{ 'Accept' = 'application/vnd.github+json'; 'User-Agent' = 'RealViewOn-update-tools' }
+    if ($GitHubToken) { $h['Authorization'] = "Bearer $GitHubToken" }
+    return $h
+}
+
+function Get-LatestStableRelease {
+    param([string] $Repo)
+    $releases = Invoke-RestMethod -Uri "https://api.github.com/repos/$Repo/releases?per_page=50" -Headers (Get-ApiHeaders)
+    $estables = @($releases | Where-Object {
+        (-not $_.draft) -and (-not $_.prerelease) -and
+        ($_.tag_name -notmatch $PatronInestable) -and
+        ([string]::IsNullOrEmpty($_.name) -or ($_.name -notmatch $PatronInestable))
+    })
+    if ($estables.Count -eq 0) { throw "$Repo no tiene ningun release estable en las ultimas 50 entradas." }
+    return ($estables | Sort-Object -Property @{ Expression = { Get-VersionSortKey ($_.tag_name) } } -Descending)[0]
+}
+
+function Get-VersionFromTag {
+    param([string] $Tag)
+    return ($Tag -replace '^[vV]', '')
+}
+
+function Get-PeMachine {
+    param([string] $Ruta)
+    $fs = [System.IO.File]::OpenRead($Ruta)
+    try {
+        $br = New-Object System.IO.BinaryReader($fs)
+        $fs.Position = 0x3C
+        $peOffset = $br.ReadInt32()
+        $fs.Position = $peOffset
+        if ($br.ReadUInt32() -ne 0x00004550) { throw "$Ruta no es un PE valido (falta la firma 'PE')." }
+        switch ($br.ReadUInt16()) {
+            0x8664  { 'x64' }
+            0x014c  { 'x86' }
+            0xAA64  { 'ARM64' }
+            default { 'desconocida' }
+        }
+    } finally { $fs.Dispose() }
+}
+
+function Get-Sha256 { param([string] $Ruta) (Get-FileHash -Path $Ruta -Algorithm SHA256).Hash }
+
+# --- Pruebas funcionales -----------------------------------------------------
+# Un binario que descarga bien pero no comprime no sirve. Estas pruebas usan los
+# mismos flags que el pipeline de release, para que el PR llegue ya verificado.
+
+function Test-BinarioUpx {
+    param([string] $Exe, [string] $VersionEsperada, [string] $SujetoPe, [string] $Trabajo)
+    $version = (& $Exe --version 2>&1) -join "`n"
+    if ($version -notmatch [regex]::Escape($VersionEsperada)) {
+        throw "'upx --version' no reporta $VersionEsperada. Salida: $version"
+    }
+
+    $copia = Join-Path $Trabajo 'sujeto.exe'
+    Copy-Item -LiteralPath $SujetoPe -Destination $copia -Force
+    $antes = (Get-Item $copia).Length
+
+    # --ultra-brute es el flag que usa ReleaseUPXZIP.bat y msbuild.yml.
+    & $Exe --ultra-brute -q $copia *> $null
+    if ($LASTEXITCODE -ne 0) { throw "'upx --ultra-brute' fallo con exit code $LASTEXITCODE." }
+    $despues = (Get-Item $copia).Length
+    if ($despues -ge $antes) { throw "UPX no redujo el ejecutable ($antes -> $despues bytes)." }
+
+    & $Exe -t $copia *> $null
+    if ($LASTEXITCODE -ne 0) { throw "'upx -t' rechazo el ejecutable comprimido." }
+
+    # Lo que realmente importa: el binario comprimido todavia corre.
+    $salida = (& $copia 2>&1) -join "`n"
+    if ([string]::IsNullOrWhiteSpace($salida)) { throw "El ejecutable comprimido no produjo salida al ejecutarse." }
+
+    $pct = [math]::Round(((($antes - $despues) / $antes) * 100), 1)
+    return "comprimio el sujeto de prueba $antes -> $despues bytes (-$pct%), 'upx -t' OK, y el binario comprimido sigue ejecutandose"
+}
+
+function Test-Binario7zr {
+    param([string] $Exe, [string] $VersionEsperada, [string] $Trabajo)
+    $banner = (& $Exe 2>&1) -join "`n"
+    if ($banner -notmatch [regex]::Escape($VersionEsperada)) {
+        throw "El banner de 7zr no reporta $VersionEsperada. Salida: $banner"
+    }
+
+    $origen = Join-Path $Trabajo 'origen'
+    New-Item -ItemType Directory -Force -Path $origen | Out-Null
+    Set-Content -Path (Join-Path $origen 'texto.txt') -Value ('RealViewOn ' * 800) -Encoding utf8
+    Copy-Item -LiteralPath $Exe -Destination (Join-Path $origen 'binario.exe') -Force
+    $esperado = Get-Sha256 (Join-Path $origen 'binario.exe')
+
+    # Mismos flags que usa el paso "Prepare release assets".
+    $archivo = Join-Path $Trabajo 'prueba.7z'
+    & $Exe a -t7z -mx=9 -md=1m -ms=on $archivo (Join-Path $origen '*') *> $null
+    if ($LASTEXITCODE -ne 0) { throw "'7zr a' fallo con exit code $LASTEXITCODE." }
+    if (-not (Test-Path $archivo)) { throw "'7zr a' no genero el archivo." }
+
+    & $Exe t $archivo *> $null
+    if ($LASTEXITCODE -ne 0) { throw "'7zr t' fallo con exit code $LASTEXITCODE." }
+
+    # Round trip completo: extraer y comparar hash, no solo confiar en el exit code.
+    $destino = Join-Path $Trabajo 'extraido'
+    & $Exe x $archivo "-o$destino" -y *> $null
+    if ($LASTEXITCODE -ne 0) { throw "'7zr x' fallo con exit code $LASTEXITCODE." }
+    $obtenido = Get-Sha256 (Join-Path $destino 'binario.exe')
+    if ($obtenido -ne $esperado) { throw "El round trip corrompio los datos: $esperado != $obtenido." }
+
+    $tam = (Get-Item $archivo).Length
+    return "creo un .7z de $tam bytes con los flags de release, '7zr t' OK, y el round trip extraccion+SHA256 coincide"
+}
+
+function Invoke-PruebaFuncional {
+    param($Herramienta, [string] $Exe, [string] $Version, [string] $Raiz, [string] $Trabajo)
+    switch ($Herramienta.id) {
+        'upx' {
+            # Se comprime el 7zr.exe del repo: un PE real, chico y a mano.
+            $sujeto = Join-Path $Raiz 'tools/7zr.exe'
+            if (-not (Test-Path $sujeto)) { throw "Falta el sujeto de prueba $sujeto." }
+            return Test-BinarioUpx -Exe $Exe -VersionEsperada $Version -SujetoPe $sujeto -Trabajo $Trabajo
+        }
+        '7zr'   { return Test-Binario7zr -Exe $Exe -VersionEsperada $Version -Trabajo $Trabajo }
+        default { return "sin prueba funcional definida para '$($Herramienta.id)'" }
+    }
+}
+
+# --- Descarga y reemplazo ----------------------------------------------------
+
+function Resolve-AssetName {
+    param([string] $Plantilla, [string] $Version)
+    return ($Plantilla -replace '\{version\}', $Version)
+}
+
+function Get-BinarioDelRelease {
+    param($Herramienta, $Release, [string] $Version, [string] $Trabajo)
+    $nombreAsset = Resolve-AssetName $Herramienta.asset $Version
+    $asset = $Release.assets | Where-Object { $_.name -eq $nombreAsset } | Select-Object -First 1
+    if (-not $asset) {
+        $disponibles = ($Release.assets | ForEach-Object { $_.name }) -join ', '
+        throw "El release $($Release.tag_name) de $($Herramienta.repo) no publica '$nombreAsset'. Assets disponibles: $disponibles"
+    }
+
+    $descarga = Join-Path $Trabajo $nombreAsset
+    Write-Host "    descargando $nombreAsset ($([math]::Round($asset.size / 1KB, 1)) KB)"
+    Invoke-WebRequest -Uri $asset.browser_download_url -OutFile $descarga -UseBasicParsing -Headers @{ 'User-Agent' = 'RealViewOn-update-tools' }
+
+    if ($Herramienta.archiveMember) {
+        $miembro = Resolve-AssetName $Herramienta.archiveMember $Version
+        $extraido = Join-Path $Trabajo 'zip'
+        Expand-Archive -LiteralPath $descarga -DestinationPath $extraido -Force
+        $ruta = Join-Path $extraido ($miembro -replace '/', [System.IO.Path]::DirectorySeparatorChar)
+        if (-not (Test-Path $ruta)) {
+            $contenido = (Get-ChildItem $extraido -Recurse -File | ForEach-Object { $_.FullName.Substring($extraido.Length + 1) }) -join ', '
+            throw "El asset no contiene '$miembro'. Contenido: $contenido"
+        }
+        return [pscustomobject]@{ Binario = $ruta; AssetUrl = $asset.browser_download_url; AssetName = $nombreAsset }
+    }
+
+    return [pscustomobject]@{ Binario = $descarga; AssetUrl = $asset.browser_download_url; AssetName = $nombreAsset }
+}
+
+function Invoke-ToolCheck {
+    param($Herramienta, [string] $Raiz)
+
+    Write-Host "==> $($Herramienta.name) [$($Herramienta.id)]"
+    $rutaLocal = Join-Path $Raiz $Herramienta.path
+    if (-not (Test-Path $rutaLocal)) { throw "Falta el binario vendorizado: $rutaLocal" }
+
+    # El lock es la referencia, pero si no coincide con el binario en disco alguien
+    # lo cambio a mano y el resto del razonamiento no seria confiable.
+    $shaLocal = Get-Sha256 $rutaLocal
+    if ($Herramienta.sha256 -and ($shaLocal -ne $Herramienta.sha256)) {
+        throw ("El SHA256 de $($Herramienta.path) no coincide con tools.lock.json.`n" +
+               "  en disco : $shaLocal`n" +
+               "  en lock  : $($Herramienta.sha256)`n" +
+               "Actualiza el lock a mano antes de dejar que el bot lo maneje.")
+    }
+
+    $release = Get-LatestStableRelease -Repo $Herramienta.repo
+    $ultima = Get-VersionFromTag $release.tag_name
+    $actual = $Herramienta.version
+    $cmp = Compare-ToolVersion -A $ultima -B $actual
+
+    Write-Host "    fijada: $actual    ultimo estable: $ultima ($($release.tag_name))"
+
+    $resultado = [pscustomobject]@{
+        Id              = $Herramienta.id
+        Nombre          = $Herramienta.name
+        Ruta            = $Herramienta.path
+        Repo            = $Herramienta.repo
+        VersionActual   = $actual
+        VersionNueva    = $ultima
+        Tag             = $release.tag_name
+        ReleaseUrl      = $release.html_url
+        # Formato fijo: ConvertFrom-Json entrega un DateTime y castearlo a string
+        # usaria la cultura del runner.
+        PublicadoEl     = ([datetime]$release.published_at).ToUniversalTime().ToString('yyyy-MM-dd')
+        HayNovedad      = ($cmp -gt 0)
+        Sha256Anterior  = $shaLocal
+        Sha256Nuevo     = $null
+        TamanoAnterior  = (Get-Item $rutaLocal).Length
+        TamanoNuevo     = $null
+        AssetName       = $null
+        AssetUrl        = $null
+        Arquitectura    = $Herramienta.arch
+        Verificacion    = $null
+        Actualizado     = $false
+    }
+
+    if ($cmp -lt 0) {
+        Write-Host "    la version fijada es MAS NUEVA que el ultimo estable publicado; no se toca." -ForegroundColor Yellow
+        return $resultado
+    }
+    if ($cmp -eq 0) {
+        Write-Host "    al dia." -ForegroundColor Green
+        return $resultado
+    }
+
+    Write-Host "    hay novedad: $actual -> $ultima" -ForegroundColor Cyan
+    if ($CheckOnly) { return $resultado }
+
+    $trabajo = Join-Path ([System.IO.Path]::GetTempPath()) ("rvo-tools-" + $Herramienta.id + "-" + [System.Guid]::NewGuid().ToString('N').Substring(0, 8))
+    New-Item -ItemType Directory -Force -Path $trabajo | Out-Null
+    try {
+        $descarga = Get-BinarioDelRelease -Herramienta $Herramienta -Release $release -Version $ultima -Trabajo $trabajo
+        $nuevo = $descarga.Binario
+
+        # Arquitectura: sin esto un cambio de nombre de asset podria meter un x86
+        # donde habia un x64 sin que nadie lo note en el diff de un binario.
+        $arch = Get-PeMachine $nuevo
+        if ($arch -ne $Herramienta.arch) {
+            throw "Arquitectura inesperada en $($descarga.AssetName): se esperaba $($Herramienta.arch) y es $arch."
+        }
+
+        if ($SkipFunctionalTest) {
+            $resultado.Verificacion = 'OMITIDA (-SkipFunctionalTest)'
+            Write-Host "    prueba funcional OMITIDA" -ForegroundColor Yellow
+        } else {
+            $resultado.Verificacion = Invoke-PruebaFuncional -Herramienta $Herramienta -Exe $nuevo -Version $ultima -Raiz $Raiz -Trabajo $trabajo
+            Write-Host "    prueba funcional OK: $($resultado.Verificacion)" -ForegroundColor Green
+        }
+
+        # La prueba de UPX comprime una copia, pero por si acaso se re-descarga el
+        # hash del binario que efectivamente se copia al repo.
+        $resultado.Sha256Nuevo = Get-Sha256 $nuevo
+        $resultado.TamanoNuevo = (Get-Item $nuevo).Length
+        $resultado.AssetName = $descarga.AssetName
+        $resultado.AssetUrl = $descarga.AssetUrl
+
+        Copy-Item -LiteralPath $nuevo -Destination $rutaLocal -Force
+        $Herramienta.version = $ultima
+        $Herramienta.sha256 = $resultado.Sha256Nuevo
+        $resultado.Actualizado = $true
+        Write-Host "    actualizado $($Herramienta.path)" -ForegroundColor Green
+    } finally {
+        Remove-Item -LiteralPath $trabajo -Recurse -Force -ErrorAction SilentlyContinue
+    }
+
+    return $resultado
+}
+
+# --- Cuerpo del PR -----------------------------------------------------------
+# Plantilla en here-string de comilla simple: sin interpolacion, asi los backticks
+# de markdown quedan literales y no hay que escaparlos.
+
+function New-CuerpoPr {
+    param($Resultado, $Herramienta)
+
+    $plantilla = @'
+## {NOMBRE} `{VIEJA}` -> `{NUEVA}`
+
+Actualizacion automatica de un binario vendorizado, detectada por
+[`update-tools.yml`](.github/workflows/update-tools.yml).
+
+|         | Antes         | Despues       |
+| ---     | ---           | ---           |
+| Version | `{VIEJA}`     | `{NUEVA}`     |
+| SHA256  | `{SHA_VIEJO}` | `{SHA_NUEVO}` |
+| Tamano  | {TAM_VIEJO} bytes | {TAM_NUEVO} bytes |
+
+- **Release de origen:** {RELEASE_URL} (tag `{TAG}`, publicado {PUBLICADO})
+- **Asset descargado:** [`{ASSET}`]({ASSET_URL})
+- **Arquitectura:** `{ARCH}`, verificada leyendo el encabezado PE. Coincide con la fijada en el lock.
+- **Usado por:** {USADO_POR}
+
+### Verificacion automatica
+
+El bot no se limito a descargar el binario: corrio una prueba funcional con los
+mismos flags que usa el pipeline de release.
+
+> {VERIFICACION}
+
+### Que revisar a mano
+
+Este PR reemplaza un ejecutable, asi que **el diff no es legible**. Antes de
+aprobar, compara el SHA256 de la tabla contra el que publica el proveedor:
+
+- UPX: <https://github.com/upx/upx/releases>
+- 7-Zip: <https://www.7-zip.org/download.html>
+
+Ninguno de los dos upstreams publica un archivo de checksums en sus releases de
+GitHub, asi que el bot **no verifica procedencia criptografica**: solo comprueba
+que el binario venga del repositorio oficial, que tenga la arquitectura esperada y
+que funcione. Comparar el hash queda a cargo de quien revisa.
+
+---
+Este PR lo creo `GITHUB_TOKEN`, por lo que **no dispara otros workflows**.
+'@
+
+    $mapa = [ordered]@{
+        '{NOMBRE}'      = [string]$Resultado.Nombre
+        '{VIEJA}'       = [string]$Resultado.VersionActual
+        '{NUEVA}'       = [string]$Resultado.VersionNueva
+        '{SHA_VIEJO}'   = [string]$Resultado.Sha256Anterior
+        '{SHA_NUEVO}'   = [string]$Resultado.Sha256Nuevo
+        '{TAM_VIEJO}'   = [string]$Resultado.TamanoAnterior
+        '{TAM_NUEVO}'   = [string]$Resultado.TamanoNuevo
+        '{RELEASE_URL}' = [string]$Resultado.ReleaseUrl
+        '{TAG}'         = [string]$Resultado.Tag
+        '{PUBLICADO}'   = [string]$Resultado.PublicadoEl
+        '{ASSET}'       = [string]$Resultado.AssetName
+        '{ASSET_URL}'   = [string]$Resultado.AssetUrl
+        '{ARCH}'        = [string]$Resultado.Arquitectura
+        '{USADO_POR}'   = [string]$Herramienta.usedBy
+        '{VERIFICACION}' = [string]$Resultado.Verificacion
+    }
+
+    $md = $plantilla
+    foreach ($clave in $mapa.Keys) { $md = $md.Replace($clave, $mapa[$clave]) }
+    return $md
+}
+
+# --- Principal ---------------------------------------------------------------
+
+$raiz = Resolve-RepoRoot $RepoRoot
+$lock = Read-Lock $raiz
+
+# El @() externo es necesario: una rama de if que devuelve un array vacio se
+# colapsa a $null al asignarla, y con Set-StrictMode el .Count siguiente explota
+# con un error que no dice nada.
+$seleccionadas = @(if ($Id -eq 'all') { $lock.tools } else { $lock.tools | Where-Object { $_.id -eq $Id } })
+if ($seleccionadas.Count -eq 0) {
+    $validos = (@($lock.tools) | ForEach-Object { $_.id }) -join ', '
+    throw "No hay ninguna herramienta con id '$Id' en tools/tools.lock.json. Ids validos: $validos"
+}
+
+$resultados = @()
+foreach ($h in $seleccionadas) {
+    $r = Invoke-ToolCheck -Herramienta $h -Raiz $raiz
+    $resultados += $r
+    if ($r.Actualizado -and $PrBodyPath) {
+        New-CuerpoPr -Resultado $r -Herramienta $h |
+            Set-Content -Path $PrBodyPath -Encoding utf8NoBOM
+        Write-Host "    cuerpo del PR escrito en $PrBodyPath"
+    }
+}
+
+if (@($resultados | Where-Object { $_.Actualizado }).Count -gt 0) { Write-Lock -Raiz $raiz -Lock $lock }
+
+# Salidas para GitHub Actions (un solo id por corrida en el workflow).
+if ($env:GITHUB_OUTPUT -and $resultados.Count -eq 1) {
+    $r = $resultados[0]
+    $pares = [ordered]@{
+        updated          = $r.Actualizado.ToString().ToLower()
+        has_update       = $r.HayNovedad.ToString().ToLower()
+        current_version  = $r.VersionActual
+        latest_version   = $r.VersionNueva
+        tag              = $r.Tag
+        release_url      = [string]$r.ReleaseUrl
+        asset_name       = [string]$r.AssetName
+        asset_url        = [string]$r.AssetUrl
+        sha256_old       = [string]$r.Sha256Anterior
+        sha256_new       = [string]$r.Sha256Nuevo
+        size_old         = [string]$r.TamanoAnterior
+        size_new         = [string]$r.TamanoNuevo
+        arch             = [string]$r.Arquitectura
+        verification     = [string]$r.Verificacion
+        name             = [string]$r.Nombre
+        repo             = [string]$r.Repo
+        path             = [string]$r.Ruta
+        published_at     = [string]$r.PublicadoEl
+    }
+    # GITHUB_OUTPUT usa "clave=valor" por linea: un salto de linea en un valor
+    # rompe el formato (y es un vector de inyeccion conocido). Todos los valores de
+    # aca son de una sola linea, pero se aplanan por si acaso.
+    foreach ($k in $pares.Keys) {
+        $v = ([string]$pares[$k]) -replace '[\r\n]+', ' '
+        "$k=$v" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+    }
+}
+
+Write-Host ''
+$resultados | Format-Table Id, VersionActual, VersionNueva, HayNovedad, Actualizado -AutoSize
+return $resultados

--- a/tools/tools.lock.json
+++ b/tools/tools.lock.json
@@ -1,0 +1,29 @@
+{
+  "comment": "Versiones fijadas de los binarios de Windows vendorizados en tools/. Lo actualiza automaticamente .github/workflows/update-tools.yml via tools/Update-VendoredTools.ps1. Ver tools/README.md.",
+  "tools": [
+    {
+      "id": "upx",
+      "name": "UPX",
+      "path": "tools/upx.exe",
+      "repo": "upx/upx",
+      "version": "5.1.1",
+      "arch": "x64",
+      "asset": "upx-{version}-win64.zip",
+      "archiveMember": "upx-{version}-win64/upx.exe",
+      "sha256": "16A29ADBDF3B6FDE74C290205E24CCEB7BEF1A216941922AA73D2D808A699BBB",
+      "usedBy": "tools/ReleaseUPXZIP.bat y el paso \"Compress with UPX\" de .github/workflows/msbuild.yml"
+    },
+    {
+      "id": "7zr",
+      "name": "7-Zip standalone console (7zr)",
+      "path": "tools/7zr.exe",
+      "repo": "ip7z/7zip",
+      "version": "26.00",
+      "arch": "x86",
+      "asset": "7zr.exe",
+      "archiveMember": null,
+      "sha256": "4BEC0BC59836A890A11568B58BD12A3E7B23A683557340562DA211B6088058BA",
+      "usedBy": "tools/ReleaseUPXZIP.bat y el paso \"Prepare release assets\" de .github/workflows/msbuild.yml"
+    }
+  ]
+}


### PR DESCRIPTION
Introduce a scheduled/manual GitHub Actions workflow to check UPX and 7zr releases, run architecture and functional validations on Windows, and open PRs when updates are available. Add `tools/Update-VendoredTools.ps1` to centralize release discovery, stable-version selection, download/extract, integrity checks, test execution, lock refresh, and PR body generation. Document the full process, constraints, and manual usage in `tools/README.md`.